### PR TITLE
FIX: Translations for table header

### DIFF
--- a/assets/javascripts/discourse/templates/admin/tickets.hbs
+++ b/assets/javascripts/discourse/templates/admin/tickets.hbs
@@ -45,12 +45,12 @@
 {{#conditional-loading-spinner condition=refreshing}}
   <table class='table users-list'>
     <thead>
-      {{table-header-toggle field="title" labelKey='tickets.dashboard_table.headings.title' order=order asc=asc}}
-      {{table-header-toggle field="tags" labelKey='tagging.tags' order=order asc=asc}}
-      {{table-header-toggle field="status" labelKey='tickets.status' order=order asc=asc}}
-      {{table-header-toggle field="priority" labelKey='tickets.priority' order=order asc=asc}}
-      {{table-header-toggle field="reason" labelKey="tickets.reason" order=order asc=asc}}
-      {{table-header-toggle field="assigned" labelKey="tickets.dashboard_table.headings.assigned" order=order asc=asc}}
+      {{table-header-toggle field="title" labelKey='tickets.dashboard_table.headings.title' order=order asc=asc automatic=true}}
+      {{table-header-toggle field="tags" labelKey='tagging.tags' order=order asc=asc automatic=true}}
+      {{table-header-toggle field="status" labelKey='tickets.status' order=order asc=asc automatic=true}}
+      {{table-header-toggle field="priority" labelKey='tickets.priority' order=order asc=asc automatic=true}}
+      {{table-header-toggle field="reason" labelKey="tickets.reason" order=order asc=asc automatic=true}}
+      {{table-header-toggle field="assigned" labelKey="tickets.dashboard_table.headings.assigned" order=order asc=asc automatic=true}}
     </thead>
     <tbody>
       {{#each tickets as |ticket|}}


### PR DESCRIPTION
Due to core changes to `table-header-toggle`, `translated=` needs to be passed in now.